### PR TITLE
Remove duplicate container from templates

### DIFF
--- a/feedthefox/base/templates/jinja2/404.html
+++ b/feedthefox/base/templates/jinja2/404.html
@@ -3,22 +3,18 @@
 {% block title%} - 404{% endblock %}
 
 {% block content %}
-  <div class="container">
+  <div class="row error">
+    <div class="col-md-6">
+      <h2>Page not found</h2>
 
-    <div class="row error">
-      <div class="col-md-6">
-        <h2>Page not found</h2>
+      <h1>404</h1>
 
-        <h1>404</h1>
-
-        <p>Looks like the page you're looking for was not found.</p>
-        <p>Head back <a href="{{ url('home') }}">home</a>.</p>
-      </div>
-
-      <div class="col-md-6">
-        <img class="img-responsive" src="{{ static('img/error.jpg') }}" alt="">
-      </div>
+      <p>Looks like the page you're looking for was not found.</p>
+      <p>Head back <a href="{{ url('home') }}">home</a>.</p>
     </div>
 
+    <div class="col-md-6">
+      <img class="img-responsive" src="{{ static('img/error.jpg') }}" alt="">
+    </div>
   </div>
 {% endblock %}

--- a/feedthefox/base/templates/jinja2/500.html
+++ b/feedthefox/base/templates/jinja2/500.html
@@ -3,22 +3,18 @@
 {% block title%} - 500{% endblock %}
 
 {% block content %}
-  <div class="container">
+  <div class="row error">
+    <div class="col-md-6">
+      <h2>Server error</h2>
 
-    <div class="row error">
-      <div class="col-md-6">
-        <h2>Server error</h2>
+      <h1>500</h1>
 
-        <h1>500</h1>
-
-        <p>Something went wrong.</p>
-        <p>Head back <a href="{{ url('home') }}">home</a>.</p>
-      </div>
-
-      <div class="col-md-6">
-        <img class="img-responsive" src="{{ static('img/error.jpg') }}" alt="">
-      </div>
+      <p>Something went wrong.</p>
+      <p>Head back <a href="{{ url('home') }}">home</a>.</p>
     </div>
 
+    <div class="col-md-6">
+      <img class="img-responsive" src="{{ static('img/error.jpg') }}" alt="">
+    </div>
   </div>
 {% endblock %}

--- a/feedthefox/base/templates/jinja2/home.html
+++ b/feedthefox/base/templates/jinja2/home.html
@@ -6,26 +6,24 @@
 
 {% block masthead %}
   <div class="clear jumbotron">
-    <div class="container">
-      <div class="row homescreen">
-        <div class="col-sm-6">
-          <div class="action">
-            <img src="{{ static('img/fxos-wordmark.svg') }}" class="img-responsive" alt="Firefox OS">
-          </div>
-          <div class="action">
-            <a href="{{ url('devices') }}" class="btn btn-success cta">Hack it on your device</a>
-          </div>
+    <div class="row homescreen">
+      <div class="col-sm-6">
+        <div class="action">
+          <img src="{{ static('img/fxos-wordmark.svg') }}" class="img-responsive" alt="Firefox OS">
         </div>
-        <div class="col-sm-6 hidden-xs">
-          <img src="{{ static('img/homescreen.png') }}" class="img-responsive homescreen-img" alt="Firefox OS Homescreen">
+        <div class="action">
+          <a href="{{ url('devices') }}" class="btn btn-success cta">Hack it on your device</a>
         </div>
+      </div>
+      <div class="col-sm-6 hidden-xs">
+        <img src="{{ static('img/homescreen.png') }}" class="img-responsive homescreen-img" alt="Firefox OS Homescreen">
       </div>
     </div>
   </div>
 {% endblock %}
 
 {% block content %}
-  <div class="container home-content">
+  <div class="home-content">
     <div class="row">
       <div class="col-md-6">
         <h2>About</h2>

--- a/feedthefox/base/templates/jinja2/profile.html
+++ b/feedthefox/base/templates/jinja2/profile.html
@@ -3,121 +3,116 @@
 {% block title%} - Profile{% endblock %}
 
 {% block content %}
-  <div class="container">
-
-    <h3></h3>
-
-    <div class="row">
-      <div class="col-sm-3 profile-details">
-        {% if user.photo %}
-          <img src="{{ user.photo }}"
-               alt="{{ user.get_full_name() }}" class="img-responsive img-circle">
-        {% else %}
-          <img src="{{ static(settings.DEFAULT_AVATAR) }}"
-               alt="{{ user.get_full_name() }}" class="img-responsive img-circle">
-        {% endif %}
-        {% if user.email %}
-          <p>
-            <span class="glyphicon glyphicon-envelope" aria-hidden="true">
-            </span>
-            {{ user.email }}
-          </p>
-        {% endif %}
+  <div class="row">
+    <div class="col-sm-3 profile-details">
+      {% if user.photo %}
+        <img src="{{ user.photo }}"
+             alt="{{ user.get_full_name() }}" class="img-responsive img-circle">
+      {% else %}
+        <img src="{{ static(settings.DEFAULT_AVATAR) }}"
+             alt="{{ user.get_full_name() }}" class="img-responsive img-circle">
+      {% endif %}
+      {% if user.email %}
         <p>
-          <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
-          <a href="{{ user|get_mozillian_url }}" target="_blank">{{ user.username }}</a>
+          <span class="glyphicon glyphicon-envelope" aria-hidden="true">
+          </span>
+          {{ user.email }}
         </p>
-        {% if user.country %}
-          <p>
-            <span class="glyphicon glyphicon-globe" aria-hidden="true"></span>
-            {{ user.country }}
-          </p>
-        {% endif %}
-      </div>
-
-      <div class="col-sm-9">
-        <h4>FoxFooding</h4>
-
-        <table class="table">
-          <thead>
-            <tr>
-              <th colspan="4">Your devices</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
-
-              </td>
-              <td class="profile-imei hidden-sm hidden-xs" title="Your IMEI number is visible only to you">
-                <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
-
-              </td>
-              <td>
-                <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                FoxFooding not enabled
-              </td>
-              <td>
-                <a href="#" class="btn btn-danger btn-xs">Delete</a>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <button class="btn btn-default" data-toggle="modal" data-target="#DeviceModal">Add device</button>
-
-        <hr>
-
-        <h4>Privacy</h4>
-
-        <form id="newsletter-form" method="post">
-          {% csrf_token %}
-          <div class="form-group">
-            <p>
-              {{ newsletter_form.receive_newsletter }}
-              I agree to receive regular emails (at least once a week) from
-              Mozilla’s Foxfooding Community Manager to provide updates on the
-              program and communicate new tasks.
-            </p>
-          <button type="submit" class="btn btn-default">Submit</button>
-          </div>
-        </form>
-
-      </div>
+      {% endif %}
+      <p>
+        <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
+        <a href="{{ user|get_mozillian_url }}" target="_blank">{{ user.username }}</a>
+      </p>
+      {% if user.country %}
+        <p>
+          <span class="glyphicon glyphicon-globe" aria-hidden="true"></span>
+          {{ user.country }}
+        </p>
+      {% endif %}
     </div>
 
+    <div class="col-sm-9">
+      <h4>FoxFooding</h4>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th colspan="4">Your devices</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+
+            </td>
+            <td class="profile-imei hidden-sm hidden-xs" title="Your IMEI number is visible only to you">
+              <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+
+            </td>
+            <td>
+              <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+              FoxFooding not enabled
+            </td>
+            <td>
+              <a href="#" class="btn btn-danger btn-xs">Delete</a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <button class="btn btn-default" data-toggle="modal" data-target="#DeviceModal">Add device</button>
+
+      <hr>
+
+      <h4>Privacy</h4>
+
+      <form id="newsletter-form" method="post">
+        {% csrf_token %}
+        <div class="form-group">
+          <p>
+            {{ newsletter_form.receive_newsletter }}
+            I agree to receive regular emails (at least once a week) from
+            Mozilla’s Foxfooding Community Manager to provide updates on the
+            program and communicate new tasks.
+          </p>
+        <button type="submit" class="btn btn-default">Save</button>
+        </div>
+      </form>
+
+    </div>
   </div>
 
-  <!-- Device Modal -->
-  <div class="modal fade" id="DeviceModal" tabindex="-1" role="dialog" aria-labelledby="DeviceModal">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title" id="DeviceModalLabel">Add device</h4>
-        </div>
-        <div class="modal-body">
-          <form>
-            <div class="form-group">
-              <select class="form-control" name="device">
-                <option value="0" selected>Select a device you own</option>
-                <option value=""></option>
-              </select>
-            </div>
-            <div class="form-group">
-              <label>IMEI</label>
-              <input id="imei-input" type="text" maxlength="15" class="form-control">
-            </div>
-            <div class="form-group imei-tos">
+</div>
 
-            </div>
-          </form>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-          <button type="button" class="btn btn-primary">Save</button>
-        </div>
+<!-- Device Modal -->
+<div class="modal fade" id="DeviceModal" tabindex="-1" role="dialog" aria-labelledby="DeviceModal">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="DeviceModalLabel">Add device</h4>
+      </div>
+      <div class="modal-body">
+        <form>
+          <div class="form-group">
+            <select class="form-control" name="device">
+              <option value="0" selected>Select a device you own</option>
+              <option value=""></option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label>IMEI</label>
+            <input id="imei-input" type="text" maxlength="15" class="form-control">
+          </div>
+          <div class="form-group imei-tos">
+
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save</button>
       </div>
     </div>
   </div>

--- a/feedthefox/dashboard/templates/jinja2/dashboard.html
+++ b/feedthefox/dashboard/templates/jinja2/dashboard.html
@@ -5,62 +5,58 @@
 {% endblock %}
 
 {% block content %}
-  <div class="container content">
+  <h3>Dashboard</h3>
 
-    <h3>Dashboard</h3>
-
-    <div class="row">
-      <div class="col-md-7 col-xs-12">
-        <input id="bug-filter" type="text"
-               class="form-control" placeholder="Start typing to filter"
-               autocomplete="off">
-      </div>
-      <div class="col-md-3 col-xs-9">
-        <div class="btn-group" role="group">
-          <button type="button" class="bug-type btn btn-default active" data-target="#features">Features</button>
-          <button type="button" class="bug-type btn btn-default" data-target="#defects">Defects</button>
-        </div>
-      </div>
-      <div class="col-md-2 col-xs-3 report">
-        <div class="dropdown">
-          <button class="btn btn-default dropdown-toggle" type="button" id="reportmenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-            <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu text-left" aria-labelledby="reportmenu">
-            <li><a href="https://bugzilla.mozilla.org/form.fxos.feature" target="_blank">Request Feature</a></li>
-            <li><a href="https://bugzilla.mozilla.org/form.fxos.feature?feature_type=Existing%20Feature%20Defect" target="_blank">Report Defect</a></li>
-          </ul>
-        </div>
+  <div class="row">
+    <div class="col-md-7 col-xs-12">
+      <input id="bug-filter" type="text"
+             class="form-control" placeholder="Start typing to filter"
+             autocomplete="off">
+    </div>
+    <div class="col-md-3 col-xs-9">
+      <div class="btn-group" role="group">
+        <button type="button" class="bug-type btn btn-default active" data-target="#features">Features</button>
+        <button type="button" class="bug-type btn btn-default" data-target="#defects">Defects</button>
       </div>
     </div>
-
-    <table class="bug-list table table-bordered table-responsive sortable">
-      <thead>
-        <tr>
-          <th class="hidden-xs text-center">Bug</th>
-          <th colspan="5">Summary</th>
-          <th class="hidden-xs hidden-sm">Component</th>
-          <th class="hidden-xs text-center" data-defaultsort="desc">Votes</th>
-        </tr>
-      </thead>
-      <tbody id="features" class="bugs-tbody">
-        <tr>
-          <td colspan="8" class="text-center">
-            <div class="loading">fetching bugs...</div>
-          </td>
-        </tr>
-      </tbody>
-      <tbody id="defects" class="bugs-tbody">
-        <tr>
-          <td colspan="8" class="text-center">
-            <div class="loading">fetching bugs...</div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
+    <div class="col-md-2 col-xs-3 report">
+      <div class="dropdown">
+        <button class="btn btn-default dropdown-toggle" type="button" id="reportmenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu text-left" aria-labelledby="reportmenu">
+          <li><a href="https://bugzilla.mozilla.org/form.fxos.feature" target="_blank">Request Feature</a></li>
+          <li><a href="https://bugzilla.mozilla.org/form.fxos.feature?feature_type=Existing%20Feature%20Defect" target="_blank">Report Defect</a></li>
+        </ul>
+      </div>
+    </div>
   </div>
+
+  <table class="bug-list table table-bordered table-responsive sortable">
+    <thead>
+      <tr>
+        <th class="hidden-xs text-center">Bug</th>
+        <th colspan="5">Summary</th>
+        <th class="hidden-xs hidden-sm">Component</th>
+        <th class="hidden-xs text-center" data-defaultsort="desc">Votes</th>
+      </tr>
+    </thead>
+    <tbody id="features" class="bugs-tbody">
+      <tr>
+        <td colspan="8" class="text-center">
+          <div class="loading">fetching bugs...</div>
+        </td>
+      </tr>
+    </tbody>
+    <tbody id="defects" class="bugs-tbody">
+      <tr>
+        <td colspan="8" class="text-center">
+          <div class="loading">fetching bugs...</div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 {% endblock %}
 
 {% block js %}

--- a/feedthefox/devices/templates/jinja2/device.html
+++ b/feedthefox/devices/templates/jinja2/device.html
@@ -1,38 +1,35 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <div class="container">
+  <h3></h3>
 
-    <h3></h3>
-
-    <div class="row">
-      <div class="col-md-4 col-sm-5">
-        <img src="" class="img-responsive">
-      </div>
-      <div class="col-md-5 col-sm-7 device-body">
-        <p></p>
-        <p>
-          <div class="device-specs device-specs-first">
-            <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
-          </div>
-          <div class="device-specs"></div>
-          <div class="device-specs"></div>
-          <div class="device-specs"></div>
-        </p>
-        <p>
-          <a href="#" class="btn btn-primary btn-lg device-doc">
-            <img src="" class="img-responsive mdn">
-            Documentation
-          </a>
-        </p>
-      </div>
-      <div class="col-md-3 col-md-offset-0 col-sm-5 col-sm-offset-5">
-        <a href="#" class="btn btn-default btn-lg device-builds">
-          <span class="glyphicon glyphicon-download img-responsive" aria-hidden="true"></span>
-          <br>
-          Build
+  <div class="row">
+    <div class="col-md-4 col-sm-5">
+      <img src="" class="img-responsive">
+    </div>
+    <div class="col-md-5 col-sm-7 device-body">
+      <p></p>
+      <p>
+        <div class="device-specs device-specs-first">
+          <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+        </div>
+        <div class="device-specs"></div>
+        <div class="device-specs"></div>
+        <div class="device-specs"></div>
+      </p>
+      <p>
+        <a href="#" class="btn btn-primary btn-lg device-doc">
+          <img src="" class="img-responsive mdn">
+          Documentation
         </a>
-      </div>
+      </p>
+    </div>
+    <div class="col-md-3 col-md-offset-0 col-sm-5 col-sm-offset-5">
+      <a href="#" class="btn btn-default btn-lg device-builds">
+        <span class="glyphicon glyphicon-download img-responsive" aria-hidden="true"></span>
+        <br>
+        Build
+      </a>
     </div>
   </div>
 {% endblock %}

--- a/feedthefox/devices/templates/jinja2/devices.html
+++ b/feedthefox/devices/templates/jinja2/devices.html
@@ -3,90 +3,87 @@
 {% block title%} - Devices{% endblock %}
 
 {% block content %}
-  <div class="container">
+  <h3>Devices</h3>
 
-    <h3>Devices</h3>
-
-    <div class="row">
-      <div class="col-sm-3">
-        <form action="" method="GET">
-          <div class="form-group">
-            <label>Manufacturer</label>
-            {{ field_with_attrs(device_filter.form.manufacturer, class="form-control") }}
-          </div>
-          <button type="submit" class="btn btn-default">Filter</button>
-        </form>
-      </div>
-      <div class="col-sm-9">
-        {% for device in device_filter %}
-          <div class="col-sm-3">
-            <a href="{{ url('device') }}" class="device-list">
-              <div>
-                <img src="{% if device.image %} {{ device.image.url }} {% endif %}"
-                     class="img-responsive" alt="{{ device.model }}">
-              </div>
-              <div>
-                <p>{{ device.comment }}</p>
-              </div>
-            </a>
-          </div>
-        {% endfor %}
-      </div>
+  <div class="row">
+    <div class="col-sm-3">
+      <form action="" method="GET">
+        <div class="form-group">
+          <label>Manufacturer</label>
+          {{ field_with_attrs(device_filter.form.manufacturer, class="form-control") }}
+        </div>
+        <button type="submit" class="btn btn-default">Filter</button>
+      </form>
     </div>
-
-    <hr>
-
-    <div class="row">
-      <div class="col-md-12 text-center">
-        <button class="btn btn-lg btn-default" id="device-not">Don't see your device here?</button>
-      </div>
+    <div class="col-sm-9">
+      {% for device in device_filter %}
+        <div class="col-sm-3">
+          <a href="{{ url('device') }}" class="device-list">
+            <div>
+              <img src="{% if device.image %} {{ device.image.url }} {% endif %}"
+                   class="img-responsive" alt="{{ device.model }}">
+            </div>
+            <div>
+              <p>{{ device.comment }}</p>
+            </div>
+          </a>
+        </div>
+      {% endfor %}
     </div>
+  </div>
 
-    <div class="row device-not-options">
-      <div class="col-sm-4 text-center">
-        <a href="{{ url('addons') }}" class="device-not-option">
-          <div>
-            <img src="{{ static('img/addons.png') }}" class="img-responsive device-not-img">
-          </div>
-          <div>
-            Add-ons
-          </div>
-          <div class="small text-muted">
-            Firefox OS 2.5 introduces support for add-ons, a feature that desktop users
-            have known and loved since the beginning of Firefox. Add-ons on Firefox OS
-            are even more powerful and can customize the whole phone experience.
-          </div>
-        </a>
-      </div>
-      <div class="col-sm-4 text-center">
-        <a href="{{ url('gaia') }}" class="device-not-option">
-          <div>
-            <img src="{{ static('img/gaia.png') }}" class="img-responsive device-not-img">
-          </div>
-          <div>
-            Gaia Development
-          </div>
-          <div class="small text-muted">
-            The focal point of Firefox OS is the user experience, and that
-            experience is a collection of Web apps called Gaia. Gaia includes
-            the core system app that implements the window manager and system UI.
-          </div>
-        </a>
-      </div>
-      <div class="col-sm-4 text-center">
-        <a href="{{ url('b2gdroid') }}" class="device-not-option">
-          <div>
-            <img src="{{ static('img/b2gdroid.png') }}" class="img-responsive device-not-img">
-          </div>
-          <div>
-            Try B2G Droid
-          </div>
-          <div class="small text-muted">
-            B2GDroid is an Android launcher that replaces the core Android
-            homescreen experience with an alternate Firefox OS experience.
-          </div>
-        </a>
-      </div>
+  <hr>
+
+  <div class="row">
+    <div class="col-md-12 text-center">
+      <button class="btn btn-lg btn-default" id="device-not">Don't see your device here?</button>
+    </div>
+  </div>
+
+  <div class="row device-not-options">
+    <div class="col-sm-4 text-center">
+      <a href="{{ url('addons') }}" class="device-not-option">
+        <div>
+          <img src="{{ static('img/addons.png') }}" class="img-responsive device-not-img">
+        </div>
+        <div>
+          Add-ons
+        </div>
+        <div class="small text-muted">
+          Firefox OS 2.5 introduces support for add-ons, a feature that desktop users
+          have known and loved since the beginning of Firefox. Add-ons on Firefox OS
+          are even more powerful and can customize the whole phone experience.
+        </div>
+      </a>
+    </div>
+    <div class="col-sm-4 text-center">
+      <a href="{{ url('gaia') }}" class="device-not-option">
+        <div>
+          <img src="{{ static('img/gaia.png') }}" class="img-responsive device-not-img">
+        </div>
+        <div>
+          Gaia Development
+        </div>
+        <div class="small text-muted">
+          The focal point of Firefox OS is the user experience, and that
+          experience is a collection of Web apps called Gaia. Gaia includes
+          the core system app that implements the window manager and system UI.
+        </div>
+      </a>
+    </div>
+    <div class="col-sm-4 text-center">
+      <a href="{{ url('b2gdroid') }}" class="device-not-option">
+        <div>
+          <img src="{{ static('img/b2gdroid.png') }}" class="img-responsive device-not-img">
+        </div>
+        <div>
+          Try B2G Droid
+        </div>
+        <div class="small text-muted">
+          B2GDroid is an Android launcher that replaces the core Android
+          homescreen experience with an alternate Firefox OS experience.
+        </div>
+      </a>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
We moved the container outside the content block for the allauth templates, so we should remove it from the rest of the templates.
