### PR TITLE
Wrap GA in DNT conditional

### DIFF
--- a/feedthefox/base/static/js/device.js
+++ b/feedthefox/base/static/js/device.js
@@ -6,12 +6,14 @@ jQuery(document).ready(function ($) {
         modal.find('#build-link').attr('href', recipient);
     });
 
-    $('a.device-builds, #build-link').click(function() {
-        ga('send', {
-            hitType: 'event',
-            eventCategory: 'FxOS Builds',
-            eventAction: 'click'
+    if (!_dntEnabled()) {
+        $('a.device-builds, #build-link').click(function() {
+            ga('send', {
+                hitType: 'event',
+                eventCategory: 'FxOS Builds',
+                eventAction: 'click'
+            });
         });
-    });
+    }
 
 });

--- a/feedthefox/base/static/js/dnt-helper.js
+++ b/feedthefox/base/static/js/dnt-helper.js
@@ -1,0 +1,46 @@
+/**
+ * Returns true or false based on whether doNotTack is enabled. It also takes into account the
+ * anomalies, such as !bugzilla 887703, which effect versions of Fx 31 and lower. It also handles
+ * IE versions on Windows 7, 8 and 8.1, where the DNT implementation does not honor the spec.
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
+ * @params {string} [dnt] - An optional mock doNotTrack string to ease unit testing.
+ * @params {string} [ua] - An optional mock userAgent string to ease unit testing.
+ * @returns {boolean} true if enabled else false
+ */
+function _dntEnabled(dnt, ua) {
+
+    'use strict';
+
+    // for old version of IE we need to use the msDoNotTrack property of navigator
+    // on newer versions, and newer platforms, this is doNotTrack but, on the window object
+    // Safari also exposes the property on the window object.
+    var dntStatus = dnt || navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
+    var ua = ua || navigator.userAgent;
+
+    // List of Windows versions known to not implement DNT according to the standard.
+    var anomalousWinVersions = ['Windows NT 6.1', 'Windows NT 6.2', 'Windows NT 6.3'];
+
+    var fxMatch = ua.match(/Firefox\/(\d+)/);
+    var ieRegEx = /MSIE|Trident/i;
+    var isIE = ieRegEx.test(ua);
+    // Matches from Windows up to the first occurance of ; un-greedily
+    // http://www.regexr.com/3c2el
+    var platform = ua.match(/Windows.+?(?=;)/g);
+
+    // With old versions of IE, DNT did not exist so we simply return false;
+    if (isIE && typeof Array.prototype.indexOf !== 'function') {
+        return false;
+    } else if (fxMatch && parseInt(fxMatch[1], 10) < 32) {
+        // Can't say for sure if it is 1 or 0, due to Fx bug 887703
+        dntStatus = 'Unspecified';
+    } else if (isIE && platform && anomalousWinVersions.indexOf(platform.toString()) !== -1) {
+        // default is on, which does not honor the specification
+        dntStatus = 'Unspecified';
+    } else {
+        // sets dntStatus to Disabled or Enabled based on the value returned by the browser.
+        // If dntStatus is undefined, it will be set to Unspecified
+        dntStatus = { '0': 'Disabled', '1': 'Enabled' }[dntStatus] || 'Unspecified';
+    }
+
+    return dntStatus === 'Enabled' ? true : false;
+}

--- a/feedthefox/base/templates/jinja2/includes/analytics.html
+++ b/feedthefox/base/templates/jinja2/includes/analytics.html
@@ -1,9 +1,12 @@
+<script src="{{ static('js/dnt-helper.js') }}"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  if (!_dntEnabled()) {
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-   ga('create', '{{ settings.GA_CODE }}', 'auto');
-   ga('send', 'pageview');
+     ga('create', '{{ settings.GA_CODE }}', 'auto');
+     ga('send', 'pageview');
+   }
 </script>


### PR DESCRIPTION
Make sure we don't hit GA for users who have "Do Not Track" enabled. This is the same implementation [bedrock has](https://github.com/mozilla/bedrock/commit/b5735136df5a4326982f98ea56a7d68500f2c2ed).
